### PR TITLE
Sub process check for Unix systems

### DIFF
--- a/src/utils/guid.py
+++ b/src/utils/guid.py
@@ -18,7 +18,7 @@ def save_uid_to_file(file_name: str, uid: str):
         with open(file_name, 'w') as file:
             file.write(uid)
     except Exception as e:
-        print('Failed to generate the UID file: {}'.format(str(e)))
+        print('[ WARNING ] Failed to generate the UID file: {}'.format(str(e)))
         return False
     return True
 

--- a/src/utils/opt_in_checker.py
+++ b/src/utils/opt_in_checker.py
@@ -240,6 +240,12 @@ class OptInChecker:
 
     @staticmethod
     def _check_main_process():
+        platform = system()
+        if platform == 'Windows':
+            # In Windows 'os' module does not have getpid() and getsid(),
+            # so the following checks are not applicable
+            return True
+
         # Check that current process is the leader of process group
         if os.getpid() != os.getpgid(0):
             return False

--- a/src/utils/opt_in_checker.py
+++ b/src/utils/opt_in_checker.py
@@ -140,25 +140,44 @@ class OptInChecker:
         Creates ISIP file directory and checks if the directory is writable.
         :return: True if the directory is created and writable, otherwise False
         """
-        if not os.path.exists(self.isip_file_base_dir()):
+        base_dir = self.isip_file_base_dir()
+        base_is_dir = os.path.isdir(base_dir)
+        base_dir_exists = os.path.exists(base_dir)
+        base_w_access = os.access(base_dir, os.W_OK)
+
+        if not base_dir_exists or not base_is_dir:
             return False
+        if not base_w_access:
+            print("[ WARNING ] Failed to create ISIP file. "
+                  "Please allow write access to the following directory: {}".format(base_dir))
+            return False
+
         isip_dir = os.path.join(self.isip_file_base_dir(), self.isip_file_subdirectory())
-        if not os.path.exists(isip_dir):
-            if not os.path.exists(self.isip_file_base_dir()):
+        isip_is_dir = os.path.isdir(isip_dir)
+        isip_dir_exists = os.path.exists(isip_dir)
+
+        # If ISIP path exists and it is not directory, we try to remove it
+        if isip_dir_exists and not isip_is_dir:
+            try:
+                os.remove(isip_dir)
+            except:
+                print('[ WARNING ] Unable to create directory for ISIP file, '
+                      'as {} is invalid directory.'.format(isip_dir))
                 return False
 
-            if not os.access(self.isip_file_base_dir(), os.W_OK):
-                print("[ WARNING ] Failed to create ISIP file. "
-                      "Please allow write access to the following directory: {}".format(self.isip_file_base_dir()))
+        if not os.path.exists(isip_dir):
+            try:
+                os.mkdir(isip_dir)
+
+                # check that directory is created
+                if not os.path.exists(isip_dir):
+                    return False
+            except Exception as e:
+                print('[ WARNING ] Failed to create directory for ISIP file: {}'.format(str(e)))
                 return False
-            os.mkdir(isip_dir)
-        if not os.path.isdir(isip_dir):
-            if not os.access(isip_dir, os.W_OK):
-                print("[ WARNING ] Failed to create ISIP file. "
-                      "Cannot create directory for ISIP file, as directory is not writable: {}".format(isip_dir))
-                return False
-            os.remove(isip_dir)
-        if not os.access(isip_dir, os.W_OK):
+
+        isip_w_access = os.access(isip_dir, os.W_OK)
+        if not isip_w_access:
             print("[ WARNING ] Failed to create ISIP file. "
                   "Please allow write access to the following directory: {}".format(isip_dir))
             return False

--- a/src/utils/opt_in_checker.py
+++ b/src/utils/opt_in_checker.py
@@ -256,6 +256,7 @@ class OptInChecker:
                 return False
         except:
             return True
+        return True
 
     @staticmethod
     def _check_run_in_notebook():

--- a/src/utils/opt_in_checker.py
+++ b/src/utils/opt_in_checker.py
@@ -246,14 +246,16 @@ class OptInChecker:
             # so the following checks are not applicable
             return True
 
-        # Check that current process is the leader of process group
-        if os.getpid() != os.getpgid(0):
-            return False
+        try:
+            # Check that current process is the leader of process group
+            if os.getpid() != os.getpgid(0):
+                return False
 
-        # Check that parent process is in same session as current process
-        if os.getsid(os.getppid()) != os.getsid(0):
-            return False
-        return True
+            # Check that parent process is in same session as current process
+            if os.getsid(os.getppid()) != os.getsid(0):
+                return False
+        except:
+            return True
 
     @staticmethod
     def _check_run_in_notebook():
@@ -272,10 +274,10 @@ class OptInChecker:
         Checks if user has accepted the collection of the information by checking the ISIP file.
         :return: opt-in dialog result
         """
-        if not self._check_input_is_terminal() or self._check_run_in_notebook():
+        if not self._check_main_process():
             return ISIPCheckResult.DECLINED
 
-        if not self._check_main_process():
+        if not self._check_input_is_terminal() or self._check_run_in_notebook():
             return ISIPCheckResult.DECLINED
 
         if not os.path.exists(self.isip_file()):

--- a/src/utils/opt_in_checker.py
+++ b/src/utils/opt_in_checker.py
@@ -6,7 +6,7 @@ import time
 from enum import Enum
 from pathlib import Path
 from platform import system
-from sys import stdin, stdout
+from sys import stdin
 
 from .colored_print import colored_print
 from .input_with_timeout import input_with_timeout

--- a/src/utils/opt_in_checker.py
+++ b/src/utils/opt_in_checker.py
@@ -6,7 +6,7 @@ import time
 from enum import Enum
 from pathlib import Path
 from platform import system
-from sys import stdin
+from sys import stdin, stdout
 
 from .colored_print import colored_print
 from .input_with_timeout import input_with_timeout
@@ -239,6 +239,17 @@ class OptInChecker:
         return stdin.isatty()
 
     @staticmethod
+    def _check_main_process():
+        # Check that current process is the leader of process group
+        if os.getpid() != os.getpgid(0):
+            return False
+
+        # Check that parent process is in same session as current process
+        if os.getsid(os.getppid()) != os.getsid(0):
+            return False
+        return True
+
+    @staticmethod
     def _check_run_in_notebook():
         """
         Checks that script is executed in Jupyter Notebook.
@@ -256,6 +267,9 @@ class OptInChecker:
         :return: opt-in dialog result
         """
         if not self._check_input_is_terminal() or self._check_run_in_notebook():
+            return ISIPCheckResult.DECLINED
+
+        if not self._check_main_process():
             return ISIPCheckResult.DECLINED
 
         if not os.path.exists(self.isip_file()):

--- a/src/utils/opt_in_checker.py
+++ b/src/utils/opt_in_checker.py
@@ -243,7 +243,9 @@ class OptInChecker:
         platform = system()
         if platform == 'Windows':
             # In Windows 'os' module does not have getpid() and getsid(),
-            # so the following checks are not applicable
+            # so the following checks are not applicable.
+            # Subprocess check in Windows is handled by self._check_input_is_terminal(),
+            # which does not work for Unix subprocesses.
             return True
 
         try:

--- a/src/utils/opt_in_checker.py
+++ b/src/utils/opt_in_checker.py
@@ -255,7 +255,8 @@ class OptInChecker:
             if os.getsid(os.getppid()) != os.getsid(0):
                 return False
         except:
-            return True
+            # If we couldn't check main process, disable opt-in dialog
+            return False
         return True
 
     @staticmethod

--- a/src/utils/opt_in_checker_test.py
+++ b/src/utils/opt_in_checker_test.py
@@ -76,9 +76,7 @@ class OptInCheckerTest(unittest.TestCase):
         os.chmod(test_subdir, 0o444)
 
         self.assertTrue(self.opt_in_checker.check() == ISIPCheckResult.NO_FILE)
-        self.assertTrue(self.opt_in_checker.create_or_check_isip_dir() is False)
-        os.chmod(test_subdir, 0o777)
-        os.remove(test_subdir)
+        self.assertTrue(self.opt_in_checker.create_or_check_isip_dir() is True)
         self.remove_test_subdir()
 
     def test_incorrect_control_file_format(self):

--- a/src/utils/opt_in_checker_test.py
+++ b/src/utils/opt_in_checker_test.py
@@ -76,7 +76,15 @@ class OptInCheckerTest(unittest.TestCase):
         os.chmod(test_subdir, 0o444)
 
         self.assertTrue(self.opt_in_checker.check() == ISIPCheckResult.NO_FILE)
-        self.assertTrue(self.opt_in_checker.create_or_check_isip_dir() is True)
+
+        # Linux allows delete read-only files, while Windows doesn't
+        if system() == 'Windows':
+            self.assertTrue(self.opt_in_checker.create_or_check_isip_dir() is False)
+            os.chmod(test_subdir, 0o777)
+            os.remove(test_subdir)
+        else:
+            self.assertTrue(self.opt_in_checker.create_or_check_isip_dir() is True)
+
         self.remove_test_subdir()
 
     def test_incorrect_control_file_format(self):

--- a/src/utils/opt_in_checker_test.py
+++ b/src/utils/opt_in_checker_test.py
@@ -22,6 +22,7 @@ class OptInCheckerTest(unittest.TestCase):
         self.opt_in_checker.isip_file_base_dir = MagicMock(return_value=self.test_directory)
         self.opt_in_checker.isip_file_subdirectory = MagicMock(return_value=self.test_subdir)
         self.opt_in_checker._check_input_is_terminal = MagicMock(return_value=True)
+        self.opt_in_checker._check_main_process = MagicMock(return_value=True)
         if not os.path.exists(self.test_directory):
             os.mkdir(os.path.join(self.test_directory))
         test_subdir = os.path.join(self.test_directory, self.test_subdir)
@@ -33,8 +34,10 @@ class OptInCheckerTest(unittest.TestCase):
         if os.path.exists(self.opt_in_checker.isip_file()):
             os.remove(self.opt_in_checker.isip_file())
         if os.path.exists(test_subdir):
+            os.chmod(test_subdir, 0o777)
             os.rmdir(test_subdir)
         if os.path.exists(self.test_directory):
+            os.chmod(self.test_directory, 0o777)
             os.rmdir(os.path.join(self.test_directory))
 
     def test_subdir_no_writable(self):


### PR DESCRIPTION
Description:
When telemetry module is used in sub processes executed from Jupiter Notebook telemetry triggers opt-in dialog.
Added check that telemetry is in sub process for Unix systems.

In Windows system this error does not reproduce because stdin.isatty() works and returns false for process executed from Jupiter Notebook. 

Ticket: 76318