### PR TITLE
Added __version__ attribute.

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,3 +2,5 @@ __all__ = [
     'Telemetry'
 ]
 from .main import Telemetry
+
+__version__ = Telemetry.get_version()


### PR DESCRIPTION
Description:
During checking of telemetry version in other tools ` __version__` attribute is used which currently does not exist in telemetry package.
Added `__version__` attribute to fix this problem.

Ticket: 76840