### PR TITLE
Fixed logic of opt-in checking for non-cmd tools.

### DIFF
--- a/src/utils/opt_in_checker.py
+++ b/src/utils/opt_in_checker.py
@@ -278,13 +278,12 @@ class OptInChecker:
         Checks if user has accepted the collection of the information by checking the ISIP file.
         :return: opt-in dialog result
         """
-        if not self._check_main_process():
-            return ISIPCheckResult.DECLINED
-
-        if not self._check_input_is_terminal() or self._check_run_in_notebook():
-            return ISIPCheckResult.DECLINED
-
         if not os.path.exists(self.isip_file()):
+            if not self._check_main_process():
+                return ISIPCheckResult.DECLINED
+
+            if not self._check_input_is_terminal() or self._check_run_in_notebook():
+                return ISIPCheckResult.DECLINED
             return ISIPCheckResult.NO_FILE
 
         if not self.isip_is_empty():

--- a/src/utils/opt_in_checker_test.py
+++ b/src/utils/opt_in_checker_test.py
@@ -121,3 +121,12 @@ class OptInCheckerTest(unittest.TestCase):
         os.rmdir(self.test_directory)
         self.assertTrue(self.opt_in_checker.create_or_check_isip_dir() is False)
         self.remove_test_subdir()
+
+    def test_send_telemetry_from_non_cmd_tool(self):
+        self.init_opt_in_checker()
+        self.opt_in_checker._check_input_is_terminal = MagicMock(return_value=False)
+        with open(self.opt_in_checker.isip_file(), 'w') as file:
+            file.write("1")
+        result = self.opt_in_checker.check()
+        self.assertTrue(result == ISIPCheckResult.ACCEPTED)
+        self.remove_test_subdir()


### PR DESCRIPTION
Description:
Currently telemetry is not sent for or non-cmd tools where input is not terminal. It happens because checks that are needed to disable opt-in dialog for non-cmd tools stand before isip file content check.

Solution: 
Change logic with the following:
If isip file exists on the system send telemetry from all tools.
If isif file does not exists check that input is not terminal and other checks and run opt-in dialog.

Ticket: 92925