### PR TITLE
Temporarily returned old consent file name for 2022.1.2 release.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -266,4 +266,4 @@ class Telemetry(metaclass=SingletonMetaClass):
         """
         Returns version of telemetry library.
         """
-        return '2022.1.1'
+        return '2022.1.2'

--- a/src/utils/opt_in_checker.py
+++ b/src/utils/opt_in_checker.py
@@ -123,7 +123,7 @@ class OptInChecker:
         Returns the ISIP file path.
         :return: ISIP file path.
         """
-        return os.path.join(self.isip_file_base_dir(), self.isip_file_subdirectory(), "openvino_telemetry")
+        return os.path.join(self.isip_file_base_dir(), self.isip_file_subdirectory(), "isip")
 
     def create_new_isip_file(self):
         """


### PR DESCRIPTION
Temporarily returned "isip" name for 2022.1.2.
Updated telemetry version.